### PR TITLE
Rel1_43

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		"semantic web",
 		"wikidata"
 	],
-	"homepage": "https://github.com/ProfessionalWiki/SemanticWikibase",
+	"homepage": "https://github.com/baillyk/SemanticWikibase",
 	"license": "GPL-2.0-or-later",
 	"authors": [
 		{

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "professional-wiki/semantic-wikibase",
+	"name": "baillyk/semantic-wikibase",
 	"type": "mediawiki-extension",
 	"description": "MediaWiki extension that makes Wikibase data available in Semantic MediaWiki",
 	"keywords": [

--- a/extension.json
+++ b/extension.json
@@ -38,9 +38,11 @@
 	"callback": "MediaWiki\\Extension\\SemanticWikibase\\EntryPoints\\HookHandlers::onExtensionRegistration",
 
 	"Hooks": {
+		"ParserFirstCallInit":"MediaWiki\\Extension\\SemanticWikibase\\EntryPoints\\HookHandlers::onParserFirstCallInit",
 		"SMW::Property::initProperties": "MediaWiki\\Extension\\SemanticWikibase\\EntryPoints\\HookHandlers::onSmwInitProperties",
 		"SMW::SQLStore::AddCustomFixedPropertyTables": "MediaWiki\\Extension\\SemanticWikibase\\EntryPoints\\HookHandlers::onSmwAddCustomFixedPropertyTables",
-		"SMWStore::updateDataBefore": "MediaWiki\\Extension\\SemanticWikibase\\EntryPoints\\HookHandlers::onSmwUpdateDataBefore"
+		"SMW::SQLStore::BeforeDataUpdateComplete": "MediaWiki\\Extension\\SemanticWikibase\\EntryPoints\\HookHandlers::onSmwUpdateDataBefore",
+		"MultiContentSave": "MediaWiki\\Extension\\SemanticWikibase\\EntryPoints\\HookHandlers::onMultiContentSave"
 	},
 
 	"config": {

--- a/src/EntryPoints/HookHandlers.php
+++ b/src/EntryPoints/HookHandlers.php
@@ -4,10 +4,21 @@ declare( strict_types = 1 );
 
 namespace MediaWiki\Extension\SemanticWikibase\EntryPoints;
 
+use MediaWiki\Revision\RenderedRevision;
+use MediaWiki\User\UserIdentity;
+use CommentStoreComment;
+use Status;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\TitleFactory;
 use MediaWiki\Extension\SemanticWikibase\SemanticWikibase;
+use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\PropertyRegistry;
 use SMW\SemanticData;
+use SMW\DIWikiPage;
+use SMW\StoreFactory;
 use SMW\Store;
+
+use Parser;
 
 class HookHandlers {
 
@@ -17,18 +28,52 @@ class HookHandlers {
 		$smwgNamespacesWithSemanticLinks[WB_NS_PROPERTY] = true;
 	}
 
+	public static function onParserFirstCallInit( Parser $parser ) {
+		# getInstance() will call initProperties() which aktivates existing hook onSmwInitProperties()
+		wfDebug( __METHOD__ . "SWB: onParserFirstCallInit" );
+		PropertyRegistry::getInstance();
+	}
+
 	public static function onSmwInitProperties( PropertyRegistry $propertyRegistry ): void {
-		SemanticWikibase::getGlobalInstance()->registerProperties( $propertyRegistry );
+		wfDebug( __METHOD__ . "SWB: onSmwInitProperties..." );
+		SemanticWikibase::getGlobalInstance()->registerProperties( $propertyRegistry );	
 	}
 
 	public static function onSmwAddCustomFixedPropertyTables( array &$customFixedProperties, array &$fixedPropertyTablePrefix ): void {
+		wfDebug( __METHOD__ . "SWB: onSmwAddCustomFixedPropertyTables" );
 		SemanticWikibase::getGlobalInstance()->getFixedProperties()
 			->registerFixedTables( $customFixedProperties, $fixedPropertyTablePrefix );
 	}
 
 	public static function onSmwUpdateDataBefore( Store $store, SemanticData $semanticData ): void {
+		wfDebug( __METHOD__ . "SWB: onSmwUpdateDataBefore" );
 		SemanticWikibase::getGlobalInstance()->getSemanticDataUpdate()
 			->run( $semanticData );
+
 	}
+
+	public static function onPageSaveComplete( WikiPage $wikiPage, MediaWiki\User\UserIdentity $user, string $summary, int $flags, MediaWiki\Revision\RevisionRecord $revisionRecord, MediaWiki\Storage\EditResult $editResult ) {
+        wfDebug( __METHOD__ . "SWB: onPageSaveComplete" );
+		// Access the semantic data of the page via the Semantic MediaWiki API
+        $semanticData = \SMW\MediaWiki\Hooks\ParserHooks::getSemanticDataForPage($wikiPage);
+
+        onSmwUpdateDataBefore(null, $semanticData);
+    }
+
+	public static function onMultiContentSave( RenderedRevision $renderedRevision, UserIdentity $user, CommentStoreComment $summary, $flags, Status $hookStatus ) {
+		wfDebug( __METHOD__ . "SWB: onMultiContentSave" );
+        $revision = $renderedRevision->getRevision();
+		
+		$titleFactory = MediaWikiServices::getInstance()->getTitleFactory();
+        $title = $titleFactory->newFromLinkTarget($revision->getPageAsLinkTarget());
+		wfDebug( __METHOD__ . "SWB: onMultiContentSave...title:".$title );
+		$subject = DIWikiPage::newFromTitle( $title );
+        #$new_content = $revision->getContent(SlotRecord::MAIN, RevisionRecord::RAW)->getNativeData();
+		$semanticData = StoreFactory::getStore()->getSemanticData( DIWikiPage::newFromTitle( $title ) );
+		wfDebug( __METHOD__ . "SWB: onMultiContentSave: ".json_encode($semanticData) );
+        SemanticWikibase::getGlobalInstance()->getSemanticDataUpdate()->run( $semanticData );
+
+        return true;
+    } 
 
 }

--- a/src/SMW/SemanticEntity.php
+++ b/src/SMW/SemanticEntity.php
@@ -8,13 +8,19 @@ use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\SemanticData;
 use SMWDataItem;
+use SMW\Subobject;
 
 class SemanticEntity {
 
 	private array $dataItemsPerProperty = [];
+	private array $subObjectsPerProperty=[];
 
 	public function addPropertyValue( string $NumericPropertyId, SMWDataItem $dataItem ) {
 		$this->dataItemsPerProperty[$NumericPropertyId][] = $dataItem;
+	}
+
+	public function addSubobject( string $NumericPropertyId, SubObject $subobject ){
+		$this->subObjectsPerProperty[$NumericPropertyId][] = $subobject;
 	}
 
 	/**
@@ -36,6 +42,14 @@ class SemanticEntity {
 					$property,
 					$dataItem
 				);
+			}
+		}
+
+		foreach ( $this->subObjectsPerProperty as $NumericPropertyId => $subobjects ) {
+			$property = new DIProperty( $NumericPropertyId );
+
+			foreach ( $subobjects as $subobject ) {
+				$semanticData->addSubobject($subobject);
 			}
 		}
 

--- a/src/SMW/SemanticEntity.php
+++ b/src/SMW/SemanticEntity.php
@@ -13,23 +13,23 @@ class SemanticEntity {
 
 	private array $dataItemsPerProperty = [];
 
-	public function addPropertyValue( string $propertyId, SMWDataItem $dataItem ) {
-		$this->dataItemsPerProperty[$propertyId][] = $dataItem;
+	public function addPropertyValue( string $NumericPropertyId, SMWDataItem $dataItem ) {
+		$this->dataItemsPerProperty[$NumericPropertyId][] = $dataItem;
 	}
 
 	/**
-	 * @param string $propertyId
+	 * @param string $NumericPropertyId
 	 * @return SMWDataItem[]
 	 */
-	public function getDataItemsForProperty( string $propertyId ): array {
-		return $this->dataItemsPerProperty[$propertyId] ?? [];
+	public function getDataItemsForProperty( string $NumericPropertyId ): array {
+		return $this->dataItemsPerProperty[$NumericPropertyId] ?? [];
 	}
 
 	public function toSemanticData( DIWikiPage $subject ): SemanticData {
 		$semanticData = new SemanticData( $subject );
 
-		foreach ( $this->dataItemsPerProperty as $propertyId => $dataItems ) {
-			$property = new DIProperty( $propertyId );
+		foreach ( $this->dataItemsPerProperty as $NumericPropertyId => $dataItems ) {
+			$property = new DIProperty( $NumericPropertyId );
 
 			foreach ( $dataItems as $dataItem ) {
 				$semanticData->addPropertyObjectValue(
@@ -52,9 +52,9 @@ class SemanticEntity {
 	}
 
 	public function add( self $entity ): void {
-		foreach ( $entity->dataItemsPerProperty as $propertyId => $dataItems ) {
+		foreach ( $entity->dataItemsPerProperty as $NumericPropertyId => $dataItems ) {
 			foreach ( $dataItems as $dataItem ) {
-				$this->addPropertyValue( $propertyId, $dataItem );
+				$this->addPropertyValue( $NumericPropertyId, $dataItem );
 			}
 		}
 	}

--- a/src/SemanticDataUpdate.php
+++ b/src/SemanticDataUpdate.php
@@ -12,7 +12,7 @@ use SMW\DIWikiPage;
 use SMW\SemanticData;
 use Title;
 use Wikibase\DataModel\Entity\ItemId;
-use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Entity\NumericPropertyId;
 use Wikibase\DataModel\Services\Lookup\ItemLookup;
 use Wikibase\DataModel\Services\Lookup\PropertyLookup;
 
@@ -64,7 +64,7 @@ class SemanticDataUpdate {
 
 	private function getSemanticEntityForPropertyTitle( Title $title ): SemanticEntity {
 		return $this->newPropertyTranslator( $title )->translateProperty(
-			$this->propertyLookup->getPropertyForId( new PropertyId( $title->getText() ) )
+			$this->propertyLookup->getPropertyForId( new NumericPropertyId( $title->getText() ) )
 		);
 	}
 

--- a/src/SemanticDataUpdate.php
+++ b/src/SemanticDataUpdate.php
@@ -63,6 +63,11 @@ class SemanticDataUpdate {
 	}
 
 	private function getSemanticEntityForPropertyTitle( Title $title ): SemanticEntity {
+		wfDebug(__METHOD__. "swb: getSemanticEntity:".json_encode($title));
+		wfDebug(__METHOD__. "swb: getSemanticEntity:".json_encode($title->getText()));
+		wfDebug(__METHOD__. "swb: getSemanticEntity:".json_encode(new NumericPropertyId( $title->getText() )));
+		wfDebug(__METHOD__. "swb: getSemanticEntity:".json_encode($this->propertyLookup->getPropertyForId( new NumericPropertyId( $title->getText() ) )));
+		
 		return $this->newPropertyTranslator( $title )->translateProperty(
 			$this->propertyLookup->getPropertyForId( new NumericPropertyId( $title->getText() ) )
 		);

--- a/src/SemanticWikibase.php
+++ b/src/SemanticWikibase.php
@@ -62,15 +62,17 @@ class SemanticWikibase {
 	}
 
 	public function registerProperties( PropertyRegistry $propertyRegistry ) {
+		wfDebug("SWB: register properties ".json_encode($this->getAllProperties()));
 		foreach ( $this->getAllProperties() as $property ) {
 			$propertyRegistry->registerProperty(
 				$property->getId(),
 				$property->getType(),
 				$property->getLabel(),
-				true,
-				false
+				true, #is_visible
+				true, #is_annotable
+				false #is_declarative
 			);
-
+			wfDebug("SWB: register property ".$property->getId());
 			foreach ( $property->getAliases() as $alias ) {
 				$propertyRegistry->registerPropertyAlias( $property->getId(), $alias );
 			}

--- a/src/SemanticWikibase.php
+++ b/src/SemanticWikibase.php
@@ -73,6 +73,7 @@ class SemanticWikibase {
 				false #is_declarative
 			);
 			wfDebug("SWB: register property ".$property->getId());
+			wfDebug("SWB: register property ".$property->getType());
 			foreach ( $property->getAliases() as $alias ) {
 				$propertyRegistry->registerPropertyAlias( $property->getId(), $alias );
 			}

--- a/src/Translation/DataValueTranslator.php
+++ b/src/Translation/DataValueTranslator.php
@@ -151,7 +151,13 @@ class DataValueTranslator {
 				$edtfValue->getMinute(),
 				$edtfValue->getSecond()
 			);
-		} 
+		} else {
+		$result = new \SMWDITime(
+				SMWDITime::CM_GREGORIAN,
+				0
+			);
+				
+		}
 	
 		return $result;
 	}

--- a/src/Translation/DataValueTranslator.php
+++ b/src/Translation/DataValueTranslator.php
@@ -19,7 +19,7 @@ use SMWDIUri;
 use Wikibase\DataModel\Entity\EntityId;
 use Wikibase\DataModel\Entity\EntityIdValue;
 use Wikibase\DataModel\Entity\ItemId;
-use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Entity\NumericPropertyId;
 
 class DataValueTranslator {
 
@@ -78,7 +78,7 @@ class DataValueTranslator {
 			return WB_NS_ITEM;
 		}
 
-		if ( $idValue instanceof PropertyId ) {
+		if ( $idValue instanceof NumericPropertyId ) {
 			return WB_NS_PROPERTY;
 		}
 

--- a/src/Translation/DataValueTranslator.php
+++ b/src/Translation/DataValueTranslator.php
@@ -154,7 +154,7 @@ class DataValueTranslator {
 		} else {
 		$result = new \SMWDITime(
 				SMWDITime::CM_GREGORIAN,
-				0
+				1970
 			);
 				
 		}

--- a/src/Translation/DataValueTranslator.php
+++ b/src/Translation/DataValueTranslator.php
@@ -22,12 +22,16 @@ use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\NumericPropertyId;
 use EDTF\Services\TimeValueBuilder;
 use EDTF\EdtfValue;
+use MediaWiki\Logger\LoggerFactory;
 
 class DataValueTranslator {
 
 	public function translate( TypedDataValue $typedValue ): SMWDataItem {
+		
+		
 		$value = $typedValue->getValue();
-		wfDebug("swb: translate". get_class( $value ));
+		
+		
 		if ( $value instanceof StringValue ) {
 			return $this->translateStringValue( $typedValue );
 		}
@@ -46,11 +50,13 @@ class DataValueTranslator {
 		if ( $value instanceof GlobeCoordinateValue ) {
 			return $this->translateGlobeCoordinateValue( $value );
 		}
+		
 		if ( $value instanceof TimeValue ) {
+			
 			return $this->translateTimeValue( $value );
 		}
 		if ( $value instanceof EdtfValue ) {
-			wfDebug("swb: translate edtf");
+			
 			$tvb = new TimeValueBuilder( EdtfFactory::newParser() );
 			return $tvb->singleValueEdtfToTimeValue($value);
 		}

--- a/src/Translation/DataValueTranslator.php
+++ b/src/Translation/DataValueTranslator.php
@@ -43,7 +43,9 @@ class DataValueTranslator {
 			wfDebug( 'swb: translate: '. $typedValue->getValue()->getValue()  );
 			if( $propertyType == 'edtf') {
 				return $this->translateEDTF("".$value->getValue());
-			}
+			}else if ($propertyType == 'localMedia') {
+                return $this->translateLocalMedia("".$value->getValue());
+            }
 			return $this->translateStringValue( $typedValue );
 		}
 		if ( $value instanceof BooleanValue ) {
@@ -86,6 +88,12 @@ class DataValueTranslator {
 		);
 	}
 
+	private function translateLocalMedia( String $imagePage): SMWDataItem {
+			return new DIWikiPage(
+					$imagePage,
+					NS_FILE
+			);
+	}
 	private function translateEntityIdValue( EntityIdValue $idValue ): SMWDataItem {
 		return new DIWikiPage(
 			$idValue->getEntityId()->getSerialization(),

--- a/src/Translation/DataValueTranslator.php
+++ b/src/Translation/DataValueTranslator.php
@@ -152,7 +152,7 @@ class DataValueTranslator {
 				$edtfValue->getSecond()
 			);
 		} 
-		wfDebug($result->getMwTimestamp());
+	
 		return $result;
 	}
 

--- a/src/Translation/DataValueTranslator.php
+++ b/src/Translation/DataValueTranslator.php
@@ -65,7 +65,6 @@ class DataValueTranslator {
 		}
 		
 		if ( $value instanceof TimeValue ) {
-			wfDebug( 'swb: translate time: '. $$value.toString()   );
 			return $this->translateTimeValue( $value );
 		}
 		

--- a/src/Translation/ItemTranslator.php
+++ b/src/Translation/ItemTranslator.php
@@ -18,10 +18,10 @@ class ItemTranslator {
 		$this->statementListTranslator = $statementListTranslator;
 	}
 
-	public function translateItem( Item $item ): SemanticEntity {
+	public function translateItem( ?Item $item ): SemanticEntity {
 		$semanticEntity = new SemanticEntity();
 
-		if ( $item->getId() === null ) {
+		if ( $item === null || $item->getId() === null ) {
 			return $semanticEntity;
 		}
 

--- a/src/Translation/PropertyTranslator.php
+++ b/src/Translation/PropertyTranslator.php
@@ -18,10 +18,10 @@ class PropertyTranslator {
 		$this->statementListTranslator = $statementListTranslator;
 	}
 
-	public function translateProperty( Property $property ): SemanticEntity {
+	public function translateProperty( ?Property $property ): SemanticEntity {
 		$semanticEntity = new SemanticEntity();
 
-		if ( $property->getId() === null ) {
+		if ( $property === null || $property->getId() === null ) {
 			return $semanticEntity;
 		}
 

--- a/src/Translation/PropertyTranslator.php
+++ b/src/Translation/PropertyTranslator.php
@@ -6,7 +6,7 @@ namespace MediaWiki\Extension\SemanticWikibase\Translation;
 
 use MediaWiki\Extension\SemanticWikibase\SMW\SemanticEntity;
 use Wikibase\DataModel\Entity\Property;
-use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Entity\NumericPropertyId;
 
 class PropertyTranslator {
 
@@ -32,7 +32,7 @@ class PropertyTranslator {
 		return $semanticEntity;
 	}
 
-	private function addId( SemanticEntity $semanticEntity, PropertyId $itemId ): void {
+	private function addId( SemanticEntity $semanticEntity, NumericPropertyId $itemId ): void {
 		$semanticEntity->addPropertyValue(
 			FixedProperties::ID,
 			new \SMWDIBlob( $itemId->getSerialization() )

--- a/src/Translation/PropertyTypeTranslator.php
+++ b/src/Translation/PropertyTypeTranslator.php
@@ -38,10 +38,12 @@ class PropertyTypeTranslator {
 			'tabular-data' => null, // TODO
 			'entity-schema' => null, // TODO
 			'time' => SMWTimeValue::TYPE_ID,
+			'edtf' => SMWTimeValue::TYPE_ID,
 			'url' => '_uri',
 			'external-id' => ExternalIdentifierValue::TYPE_ID,
 			'wikibase-item' => '_wpg',
 			'wikibase-property' => '_wpg',
+			'localMedia' => '_wpg'
 		];
 
 		if ( class_exists( CoordinateValue::class ) ) {

--- a/src/Translation/StatementListTranslator.php
+++ b/src/Translation/StatementListTranslator.php
@@ -53,7 +53,7 @@ class StatementListTranslator {
 	}
 
 	private function NumericPropertyIdForStatement( Statement $statement ): string {
-		return UserDefinedProperties::idFromWikibaseProperty( $statement->getNumericPropertyId() );
+		return UserDefinedProperties::idFromWikibaseProperty( $statement->getPropertyId() );
 	}
 
 }

--- a/src/Translation/StatementListTranslator.php
+++ b/src/Translation/StatementListTranslator.php
@@ -9,6 +9,8 @@ use SMW\DIProperty;
 use SMW\DIWikiPage;
 use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
+use MWException;
+use SMW\PropertyRegistry;
 
 class StatementListTranslator {
 
@@ -25,6 +27,7 @@ class StatementListTranslator {
 
 		foreach ( $statements->getBestStatements()->getByRank( [ Statement::RANK_PREFERRED, Statement::RANK_NORMAL ] ) as $statement ) {
 			$this->addStatement( $semanticEntity, $statement );
+
 		}
 
 		return $semanticEntity;
@@ -48,6 +51,22 @@ class StatementListTranslator {
 					$this->NumericPropertyIdForStatement( $statement ),
 					$dataItem
 				);
+			}
+
+			// now process qualifiers
+			$qualifiers = $statement->getQualifiers();
+		    $i = 1;
+			foreach( $qualifiers as $actQualifier) {
+                $actQualifierDataItem = $this->statementTranslator->snakToDataItem($actQualifier, $statement, $this->subject);
+		
+				// TODO: do we need to handle type SMWDIContainer here?
+				//throw new MWException(json_encode($actQualifier->getDataValue()));
+				$newPropId = $statement->getPropertyId()->getSerialization()."hasQualifier".$actQualifier->getPropertyId();
+				$semanticEntity->addPropertyValue(
+					$newPropId,
+					$actQualifierDataItem
+				);
+				$i++;
 			}
 		}
 	}

--- a/src/Translation/StatementListTranslator.php
+++ b/src/Translation/StatementListTranslator.php
@@ -39,21 +39,21 @@ class StatementListTranslator {
 				$semanticEntity->addPropertyValue( DIProperty::TYPE_SUBOBJECT, $dataItem );
 
 				$semanticEntity->addPropertyValue(
-					$this->propertyIdForStatement( $statement ),
+					$this->NumericPropertyIdForStatement( $statement ),
 					$dataItem->getSemanticData()->getSubject()
 				);
 			}
 			else {
 				$semanticEntity->addPropertyValue(
-					$this->propertyIdForStatement( $statement ),
+					$this->NumericPropertyIdForStatement( $statement ),
 					$dataItem
 				);
 			}
 		}
 	}
 
-	private function propertyIdForStatement( Statement $statement ): string {
-		return UserDefinedProperties::idFromWikibaseProperty( $statement->getPropertyId() );
+	private function NumericPropertyIdForStatement( Statement $statement ): string {
+		return UserDefinedProperties::idFromWikibaseProperty( $statement->getNumericPropertyId() );
 	}
 
 }

--- a/src/Translation/StatementListTranslator.php
+++ b/src/Translation/StatementListTranslator.php
@@ -11,6 +11,9 @@ use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
 use MWException;
 use SMW\PropertyRegistry;
+use SMW\Subobject;
+use SMW\StoreFactory;
+use SMW\Store;
 
 class StatementListTranslator {
 
@@ -25,35 +28,45 @@ class StatementListTranslator {
 	public function translateStatements( StatementList $statements ): SemanticEntity {
 		$semanticEntity = new SemanticEntity();
 
+        $i = 1;
 		foreach ( $statements->getBestStatements()->getByRank( [ Statement::RANK_PREFERRED, Statement::RANK_NORMAL ] ) as $statement ) {
-			$this->addStatement( $semanticEntity, $statement );
-
+			$this->addStatement( $semanticEntity, $statement, $i );
+            $i++;
 		}
 
 		return $semanticEntity;
 	}
 
-	private function addStatement( SemanticEntity $semanticEntity, Statement $statement ): void {
-		$dataItem = $this->statementTranslator->statementToDataItem( $statement, $this->subject );
+	private function addStatement( SemanticEntity $semanticEntity, Statement $statement, $statementNr ): void {
+		$mainSnakDataItem = $this->statementTranslator->statementToDataItem( $statement, $this->subject );
 
-		if ( $dataItem !== null ) {
+		if ( $mainSnakDataItem !== null ) {
+			// first link the statement value directly via property name 
 			// TODO: belongs in statement translator
-			if ( $dataItem instanceof \SMWDIContainer ) {
-				$semanticEntity->addPropertyValue( DIProperty::TYPE_SUBOBJECT, $dataItem );
+			if ( $mainSnakDataItem instanceof \SMWDIContainer ) {
+				$semanticEntity->addPropertyValue( DIProperty::TYPE_SUBOBJECT, $mainSnakDataItem );
 
 				$semanticEntity->addPropertyValue(
 					$this->NumericPropertyIdForStatement( $statement ),
-					$dataItem->getSemanticData()->getSubject()
+					$mainSnakDataItem->getSemanticData()->getSubject()
 				);
 			}
 			else {
 				$semanticEntity->addPropertyValue(
 					$this->NumericPropertyIdForStatement( $statement ),
-					$dataItem
+					$mainSnakDataItem
 				);
 			}
 
+            // for complex data e.g. using qualifiers, we add the statement additionally as a subobject
+			$subObjs = $this->statementTranslator->statementToSubobjects($statement, $this->subject, $statementNr);
+			foreach($subObjs as $subObject ){
+				$semanticEntity->addPropertyValue( DIProperty::TYPE_SUBOBJECT, $subObject->getContainer() );
+			}
+			//$semanticEntity->addPropertyValue( 'STATEMENTS', $subObject->getContainer() );
+
 			// now process qualifiers
+			/*
 			$qualifiers = $statement->getQualifiers();
 		    $i = 1;
 			foreach( $qualifiers as $actQualifier) {
@@ -66,8 +79,8 @@ class StatementListTranslator {
 					$newPropId,
 					$actQualifierDataItem
 				);
-				$i++;
-			}
+				$i++;			
+			}*/
 		}
 	}
 

--- a/src/Translation/StatementTranslator.php
+++ b/src/Translation/StatementTranslator.php
@@ -40,7 +40,7 @@ class StatementTranslator {
 	private function snakWithSimpleDataValueToDataItem( PropertyValueSnak $snak ): SMWDataItem {
 		return $this->dataValueTranslator->translate(
 			new TypedDataValue(
-				$this->propertyTypeLookup->getDataTypeIdForProperty( $snak->getPropertyId() ),
+				$this->propertyTypeLookup->getDataTypeIdForProperty( $snak->getNumericPropertyId() ),
 				$snak->getDataValue()
 			)
 		);

--- a/src/Translation/StatementTranslator.php
+++ b/src/Translation/StatementTranslator.php
@@ -5,11 +5,15 @@ declare( strict_types = 1 );
 namespace MediaWiki\Extension\SemanticWikibase\Translation;
 
 use MediaWiki\Extension\SemanticWikibase\Wikibase\TypedDataValue;
-use SMW\DIWikiPage;
-use SMWDataItem;
 use Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookup;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
 use Wikibase\DataModel\Statement\Statement;
+use SMW\DIWikiPage;
+use SMWDataItem;
+use SMW\Subobject;
+use SMW\DataValueFactory;
+use SMW\DIProperty;
+use MWNamespace;
 
 class StatementTranslator {
 
@@ -59,4 +63,48 @@ class StatementTranslator {
 		);
 	}
 
+	public function statementToSubobjects( Statement $statement, DIWikiPage $subject , $statementNr): array {
+		$result = [];
+		$mainSnak = $statement->getMainSnak();
+		$qualifiers = $statement->getQualifiers();
+		// create a smw semantic subobject for the statement
+		$statementObj = new Subobject($subject->getTitle());
+		$statementObj->setEmptyContainerForId("statement");
+		$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('subObjectType', 'statement', false, $subject) );
+		$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('property', MWNamespace::getCanonicalName(WB_NS_PROPERTY).":".$mainSnak->getPropertyId()->getLocalPart(), false, $subject) );
+		
+		
+		$mainSnakDI = $this->snakToDataItem($mainSnak, $statement, $subject);
+		$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('value', StatementTranslator::valueDIToString($mainSnakDI), false, $subject) );
+		$result[] = $statementObj;
+		$qNr = 1;
+		foreach( $qualifiers as $actQualifier){
+			$qualifierId = "statement".$statementNr."-qualifier".$qNr;
+			$qualifierObj = new Subobject($subject->getTitle());
+			$qualifierObj->setEmptyContainerForId($qualifierId);
+			$qualifierObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('subObjectType', 'qualifier', false, $subject) );
+			$qualifierObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('property', MWNamespace::getCanonicalName(WB_NS_PROPERTY).":".$actQualifier->getPropertyId()->getLocalPart(), false, $subject) );
+			$qualifierDI = $this->snakToDataItem($actQualifier, $statement, $subject);
+			$qualifierObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('value', StatementTranslator::valueDIToString($qualifierDI), false, $subject) );
+
+			// set reference in statement obj
+			$qualifierPage = $subject->getTitle()."#".$qualifierId;
+			$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('qualifier', $qualifierPage, false, $subject) );
+			$qNr++;
+			$result[] = $qualifierObj;
+		}
+
+		return $result;
+	
+	}
+
+	private static function valueDIToString($di) : string {
+		if( $di instanceof DIWikiPage ) {
+			return $di->getTitle()."";
+		}
+		return $di."";
+
+	}
+
 }
+

--- a/src/Translation/StatementTranslator.php
+++ b/src/Translation/StatementTranslator.php
@@ -13,7 +13,8 @@ use SMWDataItem;
 use SMW\Subobject;
 use SMW\DataValueFactory;
 use SMW\DIProperty;
-use MWNamespace;
+use MediaWiki\MediaWikiServices;
+use SMWDITime;
 
 class StatementTranslator {
 
@@ -65,31 +66,56 @@ class StatementTranslator {
 
 	public function statementToSubobjects( Statement $statement, DIWikiPage $subject , $statementNr): array {
 		$result = [];
+		$wbPropertyNamespaceName = MediaWikiServices::getInstance()->getNamespaceInfo()->getCanonicalName( WB_NS_PROPERTY );
+		$smwPropertyNamespaceName = MediaWikiServices::getInstance()->getNamespaceInfo()->getCanonicalName( SMW_NS_PROPERTY );
+
 		$mainSnak = $statement->getMainSnak();
 		$qualifiers = $statement->getQualifiers();
-		// create a smw semantic subobject for the statement
-		$statementObj = new Subobject($subject->getTitle());
-		$statementObj->setEmptyContainerForId("statement");
-		$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('subObjectType', 'statement', false, $subject) );
-		$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('property', MWNamespace::getCanonicalName(WB_NS_PROPERTY).":".$mainSnak->getPropertyId()->getLocalPart(), false, $subject) );
-		
-		
 		$mainSnakDI = $this->snakToDataItem($mainSnak, $statement, $subject);
-		$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('value', StatementTranslator::valueDIToString($mainSnakDI), false, $subject) );
+		// create a smw semantic subobject for the statement
+		$statementProperty = $mainSnak->getPropertyId()->getLocalPart();
+		$statementValue = StatementTranslator::valueDIToString($mainSnakDI);
+		
+		$statementObj = new Subobject($subject->getTitle());
+		$statementObj->setEmptyContainerForId("statement".$statementNr);
+		$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('subObjectType', 'statement', false, $subject) );
+		//$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('item', $subject->getTitle(), false, $subject) );
+		$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('property_name', $statementProperty, false, $subject) );
+		$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('property_wb', $wbPropertyNamespaceName.":".$statementProperty, false, $subject) );
+		$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('property_smw', $smwPropertyNamespaceName.":".$statementProperty, false, $subject) );
+		$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('value', $statementValue, false, $subject) );
+		$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText($statementProperty, $statementValue, false, $subject) );
+		#$prop =  DIProperty::newFromUserLabel($mainSnak->getPropertyId()->getLocalPart());
+		$prop =  new DIProperty( 'semanticProperty:value');
+		wfDebug('swb: prop: '.$prop);
+		$propertyDV = DataValueFactory::getInstance()->newPropertyValueByLabel("value");
+		$propertyDI = $propertyDV->getDataItem();
+		#$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByItem($mainSnakDI, $propertyDI));
 		$result[] = $statementObj;
 		$qNr = 1;
+		$statementPage = $subject->getTitle()."#statement".$statementNr;
 		foreach( $qualifiers as $actQualifier){
+			$qualifierProperty = $actQualifier->getPropertyId()->getLocalPart();
 			$qualifierId = "statement".$statementNr."-qualifier".$qNr;
 			$qualifierObj = new Subobject($subject->getTitle());
 			$qualifierObj->setEmptyContainerForId($qualifierId);
 			$qualifierObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('subObjectType', 'qualifier', false, $subject) );
-			$qualifierObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('property', MWNamespace::getCanonicalName(WB_NS_PROPERTY).":".$actQualifier->getPropertyId()->getLocalPart(), false, $subject) );
+			//$qualifierObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('item', $subject->getTitle(), false, $subject) );
+			$qualifierObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('statement', $statementPage, false, $subject) );
+			$qualifierObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('property_name', $qualifierProperty, false, $subject) );
+			$qualifierObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('property_wb', $wbPropertyNamespaceName.":".$qualifierProperty, false, $subject) );
+			$qualifierObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('property_smw', $smwPropertyNamespaceName.":".$qualifierProperty, false, $subject) );
 			$qualifierDI = $this->snakToDataItem($actQualifier, $statement, $subject);
-			$qualifierObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('value', StatementTranslator::valueDIToString($qualifierDI), false, $subject) );
+			$qualifierValue = StatementTranslator::valueDIToString($qualifierDI);
+			$qualifierObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('value', $qualifierValue, false, $subject) );
+			$qualifierObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText($qualifierProperty, $qualifierValue, false, $subject) );
 
 			// set reference in statement obj
 			$qualifierPage = $subject->getTitle()."#".$qualifierId;
 			$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('qualifier', $qualifierPage, false, $subject) );
+			$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText($statementProperty.$statementValue, $qualifierPage, false, $subject) );
+			
+
 			$qNr++;
 			$result[] = $qualifierObj;
 		}
@@ -98,10 +124,18 @@ class StatementTranslator {
 	
 	}
 
+
+
 	private static function valueDIToString($di) : string {
+		wfDebug('smw: translate DI: '.get_class($di));
 		if( $di instanceof DIWikiPage ) {
-			return $di->getTitle()."";
+			return $di->getTitle()->getText()."";
+		} else if ( $di instanceof SMWDITime){
+			wfDebug('time:'.$di->getSerialization());
+			return $di->asDateTime()->format( 'Y-m-d H:i:s' );
+			#return "01.01.1700";
 		}
+		wfdebug('default');
 		return $di."";
 
 	}

--- a/src/Translation/StatementTranslator.php
+++ b/src/Translation/StatementTranslator.php
@@ -40,7 +40,7 @@ class StatementTranslator {
 	private function snakWithSimpleDataValueToDataItem( PropertyValueSnak $snak ): SMWDataItem {
 		return $this->dataValueTranslator->translate(
 			new TypedDataValue(
-				$this->propertyTypeLookup->getDataTypeIdForProperty( $snak->getNumericPropertyId() ),
+				$this->propertyTypeLookup->getDataTypeIdForProperty( $snak->getPropertyId() ),
 				$snak->getDataValue()
 			)
 		);

--- a/src/Translation/StatementTranslator.php
+++ b/src/Translation/StatementTranslator.php
@@ -25,8 +25,21 @@ class StatementTranslator {
 
 	public function statementToDataItem( Statement $statement, DIWikiPage $subject ): ?SMWDataItem {
 		$mainSnak = $statement->getMainSnak();
+		return $this->snakToDataItem($mainSnak, $statement, $subject);
+	}
 
-		if ( !( $mainSnak instanceof PropertyValueSnak ) ) {
+	public function statementToQualifiersDataItemList( Statement $statement, DIWikiPage $subject ): array {
+		$qualifiers = $statement->getQualifiers();
+		$result = [];
+		foreach( $qualifiers as $actQualifier) {
+            $result[] = $this->snakToDataItem($actQualifier, $statement, $subject);
+		} 
+
+		return $result;
+	}
+
+	public function snakToDataItem( PropertyValueSnak $snak, Statement $statement, DIWikiPage $subject ): ?SMWDataItem {
+		if ( !( $snak instanceof PropertyValueSnak ) ) {
 			return null;
 		}
 
@@ -34,7 +47,7 @@ class StatementTranslator {
 			return $this->containerValueTranslator->statementToDataItem( $statement, $subject );
 		}
 
-		return $this->snakWithSimpleDataValueToDataItem( $mainSnak );
+		return $this->snakWithSimpleDataValueToDataItem( $snak );
 	}
 
 	private function snakWithSimpleDataValueToDataItem( PropertyValueSnak $snak ): SMWDataItem {

--- a/src/Translation/StatementTranslator.php
+++ b/src/Translation/StatementTranslator.php
@@ -73,7 +73,7 @@ class StatementTranslator {
 		$qualifiers = $statement->getQualifiers();
 		$mainSnakDI = $this->snakToDataItem($mainSnak, $statement, $subject);
 		// create a smw semantic subobject for the statement
-		$statementProperty = $mainSnak->getPropertyId()->getLocalPart();
+		$statementProperty = $mainSnak->getPropertyId()->getSerialization();
 		$statementValue = StatementTranslator::valueDIToString($mainSnakDI);
 		
 		$statementObj = new Subobject($subject->getTitle());
@@ -85,7 +85,7 @@ class StatementTranslator {
 		$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('property_smw', $smwPropertyNamespaceName.":".$statementProperty, false, $subject) );
 		$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText('value', $statementValue, false, $subject) );
 		$statementObj->addDataValue( DataValueFactory::getInstance()->newDataValueByText($statementProperty, $statementValue, false, $subject) );
-		#$prop =  DIProperty::newFromUserLabel($mainSnak->getPropertyId()->getLocalPart());
+		
 		$prop =  new DIProperty( 'semanticProperty:value');
 		wfDebug('swb: prop: '.$prop);
 		$propertyDV = DataValueFactory::getInstance()->newPropertyValueByLabel("value");
@@ -95,7 +95,7 @@ class StatementTranslator {
 		$qNr = 1;
 		$statementPage = $subject->getTitle()."#statement".$statementNr;
 		foreach( $qualifiers as $actQualifier){
-			$qualifierProperty = $actQualifier->getPropertyId()->getLocalPart();
+			$qualifierProperty = $actQualifier->getPropertyId()->getSerialization();
 			$qualifierId = "statement".$statementNr."-qualifier".$qNr;
 			$qualifierObj = new Subobject($subject->getTitle());
 			$qualifierObj->setEmptyContainerForId($qualifierId);

--- a/src/Translation/UserDefinedProperties.php
+++ b/src/Translation/UserDefinedProperties.php
@@ -44,6 +44,8 @@ class UserDefinedProperties {
 						$this->labelLanguageCode
 					)
 				);
+			}else{
+				wfDebug("swb: cannot translate ".$propertyInfo['type']);
 			}
 		}
 

--- a/src/Translation/UserDefinedProperties.php
+++ b/src/Translation/UserDefinedProperties.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace MediaWiki\Extension\SemanticWikibase\Translation;
 
 use MediaWiki\Extension\SemanticWikibase\SMW\SemanticProperty;
-use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Entity\NumericPropertyId;
 use Wikibase\DataModel\Services\Lookup\TermLookup;
 use Wikibase\Lib\Store\PropertyInfoLookup;
 use Wikibase\Lib\Store\StorageException;
@@ -40,7 +40,7 @@ class UserDefinedProperties {
 					$this->propertyTypeTranslator->translate( $propertyInfo['type'] ),
 					$id,
 					$this->termLookup->getLabel(
-						new PropertyId( $id ),
+						new NumericPropertyId( $id ),
 						$this->labelLanguageCode
 					)
 				);
@@ -59,11 +59,11 @@ class UserDefinedProperties {
 		}
 	}
 
-	private static function idFromWikibaseString( string $propertyId ): string {
-		return  '___SWB_' . $propertyId;
+	private static function idFromWikibaseString( string $NumericPropertyId ): string {
+		return  '___SWB_' . $NumericPropertyId;
 	}
 
-	public static function idFromWikibaseProperty( PropertyId $id ): string {
+	public static function idFromWikibaseProperty( NumericPropertyId $id ): string {
 		return self::idFromWikibaseString( $id->getSerialization() );
 	}
 

--- a/tests/TestFactory.php
+++ b/tests/TestFactory.php
@@ -10,7 +10,7 @@ use MediaWiki\Extension\SemanticWikibase\Translation\ItemTranslator;
 use MediaWiki\Extension\SemanticWikibase\Translation\MonoTextTranslator;
 use MediaWiki\Extension\SemanticWikibase\Translation\StatementTranslator;
 use SMW\DIWikiPage;
-use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Entity\NumericPropertyId;
 use Wikibase\DataModel\Services\Lookup\InMemoryDataTypeLookup;
 use Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookup;
 
@@ -36,7 +36,7 @@ class TestFactory extends SemanticWikibase {
 	private function newPropertyTypeLookup(): InMemoryDataTypeLookup {
 		$lookup = new InMemoryDataTypeLookup();
 
-		$lookup->setDataTypeForProperty( new PropertyId( 'P1' ), 'string' );
+		$lookup->setDataTypeForProperty( new NumericPropertyId( 'P1' ), 'string' );
 
 		return $lookup;
 	}

--- a/tests/Unit/Translation/ContainerValueTranslatorTest.php
+++ b/tests/Unit/Translation/ContainerValueTranslatorTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMWDIContainer;
-use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Entity\NumericPropertyId;
 use Wikibase\DataModel\Snak\PropertySomeValueSnak;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
 use Wikibase\DataModel\Statement\Statement;
@@ -32,7 +32,7 @@ class ContainerValueTranslatorTest extends TestCase {
 		$container = $this->translate(
 			new Statement(
 				new PropertyValueSnak(
-					new PropertyId( 'P1' ),
+					new NumericPropertyId( 'P1' ),
 					new QuantityValue(
 						new DecimalValue( 42 ),
 						'mega awesome',
@@ -70,7 +70,7 @@ class ContainerValueTranslatorTest extends TestCase {
 		$container = $this->translate(
 			new Statement(
 				new PropertyValueSnak(
-					new PropertyId( 'P1' ),
+					new NumericPropertyId( 'P1' ),
 					new UnboundedQuantityValue(
 						new DecimalValue( 42 ),
 						'mega awesome'
@@ -111,7 +111,7 @@ class ContainerValueTranslatorTest extends TestCase {
 		$this->assertTrue( $this->newTranslator()->supportsStatement(
 			new Statement(
 				new PropertyValueSnak(
-					new PropertyId( 'P1' ),
+					new NumericPropertyId( 'P1' ),
 					new UnboundedQuantityValue(
 						new DecimalValue( 42 ),
 						'mega awesome'
@@ -125,7 +125,7 @@ class ContainerValueTranslatorTest extends TestCase {
 		$this->assertFalse( $this->newTranslator()->supportsStatement(
 			new Statement(
 				new PropertySomeValueSnak(
-					new PropertyId( 'P1' )
+					new NumericPropertyId( 'P1' )
 				)
 			)
 		) );
@@ -135,7 +135,7 @@ class ContainerValueTranslatorTest extends TestCase {
 		$this->assertFalse( $this->newTranslator()->supportsStatement(
 			new Statement(
 				new PropertyValueSnak(
-					new PropertyId( 'P1' ),
+					new NumericPropertyId( 'P1' ),
 					new BooleanValue( true )
 				)
 			)

--- a/tests/Unit/Translation/DataValueTranslatorTest.php
+++ b/tests/Unit/Translation/DataValueTranslatorTest.php
@@ -20,7 +20,7 @@ use SMWDIGeoCoord;
 use SMWDIUri;
 use Wikibase\DataModel\Entity\EntityIdValue;
 use Wikibase\DataModel\Entity\ItemId;
-use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Entity\NumericPropertyId;
 
 /**
  * @covers \MediaWiki\Extension\SemanticWikibase\Translation\DataValueTranslator
@@ -70,7 +70,7 @@ class DataValueTranslatorTest extends TestCase {
 
 		$this->assertEquals(
 			new DIWikiPage( 'P42', WB_NS_PROPERTY ),
-			$this->translate( new EntityIdValue( new PropertyId( 'P42' ) ) )
+			$this->translate( new EntityIdValue( new NumericPropertyId( 'P42' ) ) )
 		);
 	}
 

--- a/tests/Unit/Translation/ItemTranslatorTest.php
+++ b/tests/Unit/Translation/ItemTranslatorTest.php
@@ -17,7 +17,7 @@ use SMW\DIWikiPage;
 use SMWDIContainer;
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Entity\ItemId;
-use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Entity\NumericPropertyId;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\PropertySomeValueSnak;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
@@ -54,7 +54,7 @@ class ItemTranslatorTest extends SWBTestCase {
 	public function testStatementMainSnakValueIsTranslated() {
 		$item = new Item( new ItemId( 'Q1' ) );
 		$item->getStatements()->addNewStatement( new PropertyValueSnak(
-			new PropertyId( 'P1' ),
+			new NumericPropertyId( 'P1' ),
 			new StringValue( 'Hello there' )
 		) );
 
@@ -68,12 +68,12 @@ class ItemTranslatorTest extends SWBTestCase {
 		$item = new Item( new ItemId( 'Q1' ) );
 
 		$item->getStatements()->addNewStatement( new PropertyValueSnak(
-			new PropertyId( 'P1' ),
+			new NumericPropertyId( 'P1' ),
 			new StringValue( 'Hello there' )
 		) );
 
 		$item->getStatements()->addNewStatement( new PropertyValueSnak(
-			new PropertyId( 'P1' ),
+			new NumericPropertyId( 'P1' ),
 			new StringValue( 'fellow sentient' )
 		) );
 
@@ -89,8 +89,8 @@ class ItemTranslatorTest extends SWBTestCase {
 	public function testOnlyPropertyValueSnaksGetAdded() {
 		$item = new Item( new ItemId( 'Q1' ) );
 
-		$item->getStatements()->addNewStatement( new PropertyNoValueSnak( new PropertyId( 'P1' ) ) );
-		$item->getStatements()->addNewStatement( new PropertySomeValueSnak( new PropertyId( 'P1' ) ) );
+		$item->getStatements()->addNewStatement( new PropertyNoValueSnak( new NumericPropertyId( 'P1' ) ) );
+		$item->getStatements()->addNewStatement( new PropertySomeValueSnak( new NumericPropertyId( 'P1' ) ) );
 
 		$this->assertSame(
 			[],
@@ -103,7 +103,7 @@ class ItemTranslatorTest extends SWBTestCase {
 
 		$item->getStatements()->addNewStatement(
 			new PropertyValueSnak(
-				new PropertyId( 'P1' ),
+				new NumericPropertyId( 'P1' ),
 				new UnboundedQuantityValue(
 					new DecimalValue( 42 ),
 					'mega awesome'
@@ -135,7 +135,7 @@ class ItemTranslatorTest extends SWBTestCase {
 		);
 	}
 
-	private function assertHasSubobjectWithPropertyValue( SemanticEntity $semanticEntity, string $propertyId, \SMWDataItem $expectedDataItem ) {
+	private function assertHasSubobjectWithPropertyValue( SemanticEntity $semanticEntity, string $NumericPropertyId, \SMWDataItem $expectedDataItem ) {
 		/**
 		 * @var SMWDIContainer $container
 		 */
@@ -143,7 +143,7 @@ class ItemTranslatorTest extends SWBTestCase {
 
 		$this->assertEquals(
 			[ $expectedDataItem ],
-			$container->getSemanticData()->getPropertyValues( new DIProperty( $propertyId ) )
+			$container->getSemanticData()->getPropertyValues( new DIProperty( $NumericPropertyId ) )
 		);
 	}
 

--- a/tests/Unit/Translation/PropertyTranslatorTest.php
+++ b/tests/Unit/Translation/PropertyTranslatorTest.php
@@ -11,7 +11,7 @@ use MediaWiki\Extension\SemanticWikibase\Tests\TestFactory;
 use MediaWiki\Extension\SemanticWikibase\Translation\FixedProperties;
 use SMW\DIWikiPage;
 use Wikibase\DataModel\Entity\Property;
-use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Entity\NumericPropertyId;
 
 /**
  * @covers \MediaWiki\Extension\SemanticWikibase\Translation\PropertyTranslator
@@ -30,7 +30,7 @@ class PropertyTranslatorTest extends SWBTestCase {
 
 	private function newProperty(): Property {
 		return new Property(
-			new PropertyId( self::ID ),
+			new NumericPropertyId( self::ID ),
 			null,
 			self::TYPE
 		);

--- a/tests/Unit/Translation/StatementTranslatorTest.php
+++ b/tests/Unit/Translation/StatementTranslatorTest.php
@@ -13,7 +13,7 @@ use MediaWiki\Extension\SemanticWikibase\Translation\StatementTranslator;
 use PHPUnit\Framework\TestCase;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
-use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Entity\NumericPropertyId;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
 use Wikibase\DataModel\Statement\Statement;
 
@@ -32,7 +32,7 @@ class StatementTranslatorTest extends TestCase {
 			$this->newTranslator()->statementToDataItem(
 				new Statement(
 					new PropertyValueSnak(
-						new PropertyId( 'P1' ),
+						new NumericPropertyId( 'P1' ),
 						new StringValue( 'Kittens' )
 					)
 				),
@@ -45,7 +45,7 @@ class StatementTranslatorTest extends TestCase {
 		$container = $this->newTranslator()->statementToDataItem(
 			new Statement(
 				new PropertyValueSnak(
-					new PropertyId( 'P1' ),
+					new NumericPropertyId( 'P1' ),
 					new UnboundedQuantityValue(
 						new DecimalValue( 42 ),
 						'mega awesome'


### PR DESCRIPTION
updated to ensure compatibility with mediawiki 1.43
tested environment:
MW: 1.43
SMW: ^6.0.0
SRF: ~5.2
WikibaseLocalMedia: ~2
WikibaseEdtf: ^3.0.0
Maps: ~12.0
WIkibase: REL1_43

the following Wikibase Property datatypes where succesfully tested for functionality:
- EDTF
- External ID
- LocalMediaFile
- MonolingualText
- Property
- String
- Timestamp
- URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for EDTF (Extended Date/Time Format) date values.
  * Introduced local media file handling in semantic data translation.
  * Enhanced semantic data with support for qualifiers and subobjects in statements.

* **Chores**
  * Updated package metadata and repository information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->